### PR TITLE
suppress warning on video loop (probably only on windows)

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -2623,7 +2623,15 @@ with block:
                 # 代わりにcheckbox値のみに依存するシンプルな条件分岐を各関数で直接実装
 
         with gr.Column():
-            result_video = gr.Video(label=translate("Finished Frames"), autoplay=True, show_share_button=False, height=512, loop=True)
+            result_video = gr.Video(
+                label=translate("Finished Frames"), 
+                autoplay=True, 
+                show_share_button=False, 
+                height=512, 
+                loop=True,
+                format="mp4",
+                interactive=False,
+            )
             progress_desc = gr.Markdown('', elem_classes='no-generating-animation')
             progress_bar = gr.HTML('', elem_classes='no-generating-animation')
             preview_image = gr.Image(label="Next Latents", height=200, visible=False)


### PR DESCRIPTION
before:
<img width="920" alt="スクリーンショット 2025-05-03 020417" src="https://github.com/user-attachments/assets/43747d3a-9448-4f3e-bd8e-58678c8a4073" />

after:
<img width="917" alt="スクリーンショット 2025-05-03 020716" src="https://github.com/user-attachments/assets/811680f4-5234-4205-ba47-510227d4f3ef" />
