### PR TITLE
[ux update] adjust preserved GPU based on available CUDA memory

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -2729,7 +2729,9 @@ with block:
             gs = gr.Slider(label=translate("Distilled CFG Scale"), minimum=1.0, maximum=32.0, value=10.0, step=0.01, info=translate('Changing this value is not recommended.'))
             rs = gr.Slider(label=translate("CFG Re-Scale"), minimum=0.0, maximum=1.0, value=0.0, step=0.01, visible=False)  # Should not change
 
-            gpu_memory_preservation = gr.Slider(label=translate("GPU Memory to Preserve (GB) (smaller = more VRAM usage)"), minimum=6, maximum=128, value=10, step=0.1, info=translate("空けておくGPUメモリ量を指定。小さい値=より多くのVRAMを使用可能=高速、大きい値=より少ないVRAMを使用=安全"))
+            available_cuda_memory_gb = round(torch.cuda.get_device_properties(0).total_memory / (1024**3))
+            default_gpu_memory_preservation_gb = 6 if available_cuda_memory_gb >= 20 else (8 if available_cuda_memory_gb > 16 else 10)
+            gpu_memory_preservation = gr.Slider(label=translate("GPU Memory to Preserve (GB) (smaller = more VRAM usage)"), minimum=6, maximum=128, value=default_gpu_memory_preservation_gb, step=0.1, info=translate("空けておくGPUメモリ量を指定。小さい値=より多くのVRAMを使用可能=高速、大きい値=より少ないVRAMを使用=安全"))
 
             # MP4圧縮設定スライダーを追加
             mp4_crf = gr.Slider(label=translate("MP4 Compression"), minimum=0, maximum=100, value=16, step=1, info=translate("数値が小さいほど高品質になります。0は無圧縮。黒画面が出る場合は16に設定してください。"))


### PR DESCRIPTION
RTX3090(USB4接続)環境で動かしていますが、デフォルトの10GBままうっかり実行することが多く、4GBほどのVRAMを持て余しながら生成してしまうことがありました。
興味深いことに `[02:29<00:00,  5.97s/it]` vs `[02:58<00:00,  7.13s/it]` 、15%-20%ほど生成時間に影響がありました。

16GB環境の最適値はこちらでは把握していませんので、いったん10GBとしていますが、最近の挙動に合わせて値を変更するといいかもしれませんので、ご確認・ご変更ください。

よろしくお願いいたします。