### PR TITLE
[cloud UX] parallel download models prior to initialization

### DIFF
--- a/webui/eichi_utils/model_downloader.py
+++ b/webui/eichi_utils/model_downloader.py
@@ -1,0 +1,37 @@
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from huggingface_hub import snapshot_download
+
+class ModelDownloader:
+    def __init__(self, max_workers_per_model=4):    
+        # max_parallel_models > 1 は tqdm._lock が競合し異常終了するため、当面は1に固定する
+        self.max_parallel_models = 1
+        self.max_workers_per_model = max_workers_per_model
+
+    def _download_models(self, models_to_download):
+        def download_model(model_info):
+            kwargs = {
+                "repo_id": model_info["repo_id"],
+                "allow_patterns": model_info.get("allow_patterns", "*"),
+                "max_workers": self.max_workers_per_model,
+            }
+            snapshot_download(**kwargs)
+
+        with ThreadPoolExecutor(max_workers=self.max_parallel_models) as executor:
+            futures = [executor.submit(download_model, model) for model in models_to_download]
+            for future in as_completed(futures):
+                future.result()
+    
+    def download_original(self):
+        self._download_models([
+            {"repo_id": "hunyuanvideo-community/HunyuanVideo", "allow_patterns": ["tokenizer/*", "tokenizer_2/*", "vae/*", "text_encoder/*", "text_encoder_2/*"]},
+            {"repo_id": "lllyasviel/flux_redux_bfl", "allow_patterns": ["feature_extractor/*", "image_encoder/*"]},
+            {"repo_id": "lllyasviel/FramePackI2V_HY"},
+        ])
+
+    def download_f1(self):
+        self._download_models([
+            {"repo_id": "hunyuanvideo-community/HunyuanVideo", "allow_patterns": ["tokenizer/*", "tokenizer_2/*", "vae/*", "text_encoder/*", "text_encoder_2/*"]},
+            {"repo_id": "lllyasviel/flux_redux_bfl", "allow_patterns": ["feature_extractor/*", "image_encoder/*"]},
+            {"repo_id": "lllyasviel/FramePack_F1_I2V_HY_20250503"},
+        ])

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -140,6 +140,10 @@ high_vram = free_mem_gb > 100
 print(translate('Free VRAM {0} GB').format(free_mem_gb))
 print(translate('High-VRAM Mode: {0}').format(high_vram))
 
+# モデルを並列ダウンロードしておく
+from eichi_utils.model_downloader import ModelDownloader
+ModelDownloader().download_original()
+
 # グローバルなモデル状態管理インスタンスを作成
 # 通常モードではuse_f1_model=Falseを指定（デフォルト値なので省略可）
 transformer_manager = TransformerManager(device=gpu, high_vram_mode=high_vram, use_f1_model=False)

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -131,6 +131,10 @@ high_vram = free_mem_gb > 100
 print(translate('Free VRAM {0} GB').format(free_mem_gb))
 print(translate('High-VRAM Mode: {0}').format(high_vram))
 
+# モデルを並列ダウンロードしておく
+from eichi_utils.model_downloader import ModelDownloader
+ModelDownloader().download_f1()
+
 # グローバルなモデル状態管理インスタンスを作成
 # F1モードではuse_f1_model=Trueを指定
 transformer_manager = TransformerManager(device=gpu, high_vram_mode=high_vram, use_f1_model=True)

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -137,6 +137,10 @@ high_vram = free_mem_gb > 100
 print(translate('Free VRAM {0} GB').format(free_mem_gb))
 print(translate('High-VRAM Mode: {0}').format(high_vram))
 
+# モデルを並列ダウンロードしておく
+from eichi_utils.model_downloader import ModelDownloader
+ModelDownloader().download_original()
+
 # グローバルなモデル状態管理インスタンスを作成（モデルは実際に使用するまでロードしない）
 transformer_manager = TransformerManager(device=gpu, high_vram_mode=high_vram, use_f1_model=False)
 text_encoder_manager = TextEncoderManager(device=gpu, high_vram_mode=high_vram)


### PR DESCRIPTION
起動時にすべてのモデルのダウンロードを並列で行います。クラウドで動かしている時にスタートアップ時間の大幅な短縮が見込めます。

<img width="953" alt="スクリーンショット 2025-05-11 160902" src="https://github.com/user-attachments/assets/f9b3de97-527d-4c57-9071-0566c1fe9e47" />
