### PR TITLE
UI patch: no reload output_video view unless new video generates

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -2812,12 +2812,12 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         # ユーザーにわかりやすいメッセージを表示
         print(translate("\n[INFO] ランダムシード機能が有効なため、指定されたSEED値 {0} の代わりに新しいSEED値 {1} を使用します。").format(previous_seed, seed))
         # UIのseed欄もランダム値で更新
-        yield None, None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
+        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
         # ランダムシードの場合は最初の値を更新
         original_seed = seed
     else:
         print(translate("[INFO] 指定されたSEED値 {0} を使用します。").format(seed))
-        yield None, None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
+        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
     stream = AsyncStream()
 
@@ -2825,7 +2825,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
     if batch_stopped:
         print(translate("\nバッチ処理が中断されました（バッチ開始前）"))
         yield (
-            None,
+            gr.update(),
             gr.update(visible=False),
             translate("バッチ処理が中断されました"),
             '',
@@ -2841,7 +2841,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("\nバッチ処理がユーザーによって中止されました"))
             yield (
-                None,
+                gr.update(),
                 gr.update(visible=False),
                 translate("バッチ処理が中止されました。"),
                 '',
@@ -2897,7 +2897,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
 
             print(f"\n{batch_info}")
             # UIにもバッチ情報を表示
-            yield None, gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
+            yield gr.update(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
         # バッチインデックスに応じてSEED値を設定
         # ランダムシード使用判定を再度実施
@@ -2933,7 +2933,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("バッチ処理が中断されました。worker関数の実行をキャンセルします。"))
             # 中断メッセージをUIに表示
-            yield (None,
+            yield (gr.update(),
                    gr.update(visible=False),
                    translate("バッチ処理が中断されました（{0}/{1}）").format(batch_index, batch_count),
                    '',
@@ -3110,7 +3110,15 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
             if flag == 'file':
                 batch_output_filename = data
                 # より明確な更新方法を使用し、preview_imageを明示的にクリア
-                yield batch_output_filename, gr.update(value=None, visible=False), gr.update(), gr.update(), gr.update(interactive=False), gr.update(interactive=True), gr.update()
+                yield (
+                    batch_output_filename if batch_output_filename is not None else gr.update(),
+                    gr.update(value=None, visible=False),
+                    gr.update(),
+                    gr.update(),
+                    gr.update(interactive=False),
+                    gr.update(interactive=True),
+                    gr.update(),
+                )
 
             if flag == 'progress':
                 preview, desc, html = data
@@ -3157,7 +3165,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     else:
                         completion_message = translate("バッチ処理が完了しました（{0}/{1}）").format(batch_count, batch_count)
                     yield (
-                        batch_output_filename,
+                        batch_output_filename if batch_output_filename is not None else gr.update(),
                         gr.update(value=None, visible=False),
                         completion_message,
                         '',
@@ -3169,7 +3177,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     # 次のバッチに進むメッセージを表示
                     next_batch_message = translate("バッチ処理: {0}/{1} 完了、次のバッチに進みます...").format(batch_index + 1, batch_count)
                     yield (
-                        batch_output_filename,
+                        batch_output_filename if batch_output_filename is not None else gr.update(),
                         gr.update(value=None, visible=False),
                         next_batch_message,
                         '',

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -1931,12 +1931,12 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         # ユーザーにわかりやすいメッセージを表示
         print(translate("\n[INFO] ランダムシード機能が有効なため、指定されたSEED値 {0} の代わりに新しいSEED値 {1} を使用します。").format(previous_seed, seed))
         # UIのseed欄もランダム値で更新
-        yield None, None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
+        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
         # ランダムシードの場合は最初の値を更新
         original_seed = seed
     else:
         print(translate("[INFO] 指定されたSEED値 {0} を使用します。").format(seed))
-        yield None, None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
+        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
     stream = AsyncStream()
 
@@ -1944,7 +1944,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
     if batch_stopped:
         print(translate("\nバッチ処理が中断されました（バッチ開始前）"))
         yield (
-            None,
+            gr.update(),
             gr.update(visible=False),
             translate("バッチ処理が中断されました"),
             '',
@@ -1994,7 +1994,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("\nバッチ処理がユーザーによって中止されました"))
             yield (
-                None,
+                gr.update(),
                 gr.update(visible=False),
                 translate("バッチ処理が中止されました。"),
                 '',
@@ -2009,7 +2009,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
             batch_info = translate("バッチ処理: {0}/{1}").format(batch_index + 1, batch_count)
             print(f"\n{batch_info}")
             # UIにもバッチ情報を表示
-            yield None, gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
+            yield gr.update(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
         # 今回処理用のプロンプトとイメージを取得（キュー機能対応）
         current_prompt = prompt
@@ -2089,7 +2089,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("バッチ処理が中断されました。worker関数の実行をキャンセルします。"))
             # 中断メッセージをUIに表示
-            yield (None,
+            yield (gr.update(),
                    gr.update(visible=False),
                    translate("バッチ処理が中断されました（{0}/{1}）").format(batch_index, batch_count),
                    '',
@@ -2188,7 +2188,15 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
             if flag == 'file':
                 batch_output_filename = data
                 # より明確な更新方法を使用し、preview_imageを明示的にクリア
-                yield batch_output_filename, gr.update(value=None, visible=False), gr.update(), gr.update(), gr.update(interactive=False), gr.update(interactive=True), gr.update()
+                yield (
+                    batch_output_filename if batch_output_filename is not None else gr.update(), 
+                    gr.update(value=None, visible=False), 
+                    gr.update(), 
+                    gr.update(), 
+                    gr.update(interactive=False), 
+                    gr.update(interactive=True), 
+                    gr.update(),
+                )
 
             if flag == 'progress':
                 preview, desc, html = data
@@ -2209,7 +2217,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     else:
                         completion_message = translate("バッチ処理が完了しました（{0}/{1}）").format(batch_count, batch_count)
                     yield (
-                        batch_output_filename,
+                        batch_output_filename if batch_output_filename is not None else gr.update(),
                         gr.update(value=None, visible=False),
                         completion_message,
                         '',
@@ -2224,7 +2232,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     next_batch_message = translate("バッチ処理: {0}/{1} 完了、次のバッチに進みます...").format(batch_index + 1, batch_count)
                     print(translate("\n◆ バッチ {0}/{1} 完了 - 次のバッチに進みます").format(batch_index + 1, batch_count))
                     yield (
-                        batch_output_filename,
+                        batch_output_filename if batch_output_filename is not None else gr.update(),
                         gr.update(value=None, visible=False),
                         next_batch_message,
                         '',

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2207,7 +2207,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
             print(translate("[INFO] lora_dropdown3 = {0}").format(lora_dropdown3))
         print(translate("[INFO] lora_scales_text = {0}").format(lora_scales_text))
     
-    yield None, None, '', '', gr.update(interactive=False), gr.update(interactive=True)
+    yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True)
     
     # バッチ処理用の変数 - 各フラグをリセット
     batch_stopped = False
@@ -2254,7 +2254,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
         if batch_stopped:
             print(translate("\nバッチ処理がユーザーによって中止されました"))
             yield (
-                None,
+                gr.update(),
                 gr.update(visible=False),
                 translate("バッチ処理が中止されました。"),
                 '',
@@ -2268,7 +2268,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
             batch_info = translate("バッチ処理: {0}/{1}").format(batch_index + 1, batch_count)
             print(f"\n{batch_info}")
             # UIにもバッチ情報を表示
-            yield None, gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True)
+            yield gr.update(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True)
 
         # 今回処理用のプロンプトとイメージを取得（キュー機能対応）
         current_prompt = prompt
@@ -2388,7 +2388,14 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                     
                     if flag == 'file':
                         output_filename = data
-                        yield output_filename, gr.update(), gr.update(), gr.update(), gr.update(interactive=False), gr.update(interactive=True)
+                        yield (
+                            output_filename if output_filename is not None else gr.update(),
+                            gr.update(),
+                            gr.update(),
+                            gr.update(),
+                            gr.update(interactive=False),
+                            gr.update(interactive=True),
+                        )
                     
                     if flag == 'progress':
                         preview, desc, html = data
@@ -2405,7 +2412,14 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                                 completion_message = translate("バッチ処理が完了しました（{0}/{1}）").format(batch_count, batch_count)
                             
                             # 完了メッセージでUIを更新
-                            yield output_filename, gr.update(visible=False), completion_message, '', gr.update(interactive=True, value=translate("Start Generation")), gr.update(interactive=False, value=translate("End Generation"))
+                            yield (
+                                output_filename if output_filename is not None else gr.update(),
+                                gr.update(visible=False),
+                                completion_message,
+                                '',
+                                gr.update(interactive=True, value=translate("Start Generation")),
+                                gr.update(interactive=False, value=translate("End Generation")),
+                            )
                         break
                         
                     # ユーザーが中断した場合
@@ -2414,7 +2428,14 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                         # 処理ループ内での中断検出（デバッグログ削除）
                         print(translate("バッチ処理が中断されました（{0}/{1}）").format(batch_index + 1, batch_count))
                         # endframe_ichiと同様のシンプルな実装に戻す
-                        yield output_filename, gr.update(visible=False), translate("バッチ処理が中断されました"), '', gr.update(interactive=True), gr.update(interactive=False, value=translate("End Generation"))
+                        yield (
+                            output_filename if output_filename is not None else gr.update(),
+                            gr.update(visible=False),
+                            translate("バッチ処理が中断されました"),
+                            '',
+                            gr.update(interactive=True),
+                            gr.update(interactive=False, value=translate("End Generation")),
+                        )
                         return
                         
                 except Exception as e:


### PR DESCRIPTION
完了したフレーム (Finished Frame) で表示している生成済みのビデオですが、バッチの更新のタイミングや、次のプロンプトをキューするタイミングで消えてしまうので、なるべく前に表示していたものをキープするようにいたしました。

認識違いありましたらお知らせください 🙇 