### PR TITLE
UI patch: use gr.skip() instead of gr.update() to prevent unnecessary…

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -2825,12 +2825,12 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         # ユーザーにわかりやすいメッセージを表示
         print(translate("\n[INFO] ランダムシード機能が有効なため、指定されたSEED値 {0} の代わりに新しいSEED値 {1} を使用します。").format(previous_seed, seed))
         # UIのseed欄もランダム値で更新
-        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
+        yield gr.skip(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
         # ランダムシードの場合は最初の値を更新
         original_seed = seed
     else:
         print(translate("[INFO] 指定されたSEED値 {0} を使用します。").format(seed))
-        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
+        yield gr.skip(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
     stream = AsyncStream()
 
@@ -2838,7 +2838,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
     if batch_stopped:
         print(translate("\nバッチ処理が中断されました（バッチ開始前）"))
         yield (
-            gr.update(),
+            gr.skip(),
             gr.update(visible=False),
             translate("バッチ処理が中断されました"),
             '',
@@ -2854,7 +2854,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("\nバッチ処理がユーザーによって中止されました"))
             yield (
-                gr.update(),
+                gr.skip(),
                 gr.update(visible=False),
                 translate("バッチ処理が中止されました。"),
                 '',
@@ -2910,7 +2910,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
 
             print(f"\n{batch_info}")
             # UIにもバッチ情報を表示
-            yield gr.update(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
+            yield gr.skip(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
         # バッチインデックスに応じてSEED値を設定
         # ランダムシード使用判定を再度実施
@@ -2946,7 +2946,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("バッチ処理が中断されました。worker関数の実行をキャンセルします。"))
             # 中断メッセージをUIに表示
-            yield (gr.update(),
+            yield (gr.skip(),
                    gr.update(visible=False),
                    translate("バッチ処理が中断されました（{0}/{1}）").format(batch_index, batch_count),
                    '',
@@ -3124,7 +3124,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                 batch_output_filename = data
                 # より明確な更新方法を使用し、preview_imageを明示的にクリア
                 yield (
-                    batch_output_filename if batch_output_filename is not None else gr.update(),
+                    batch_output_filename if batch_output_filename is not None else gr.skip(),
                     gr.update(value=None, visible=False),
                     gr.update(),
                     gr.update(),
@@ -3166,7 +3166,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                 if current_seed_info not in desc:
                     desc = desc + "\n\n" + current_seed_info
                 # preview_imageを明示的に設定
-                yield gr.update(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True), gr.update()
+                yield gr.skip(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
             if flag == 'end':
                 # このバッチの処理が終了
@@ -3178,7 +3178,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     else:
                         completion_message = translate("バッチ処理が完了しました（{0}/{1}）").format(batch_count, batch_count)
                     yield (
-                        batch_output_filename if batch_output_filename is not None else gr.update(),
+                        batch_output_filename if batch_output_filename is not None else gr.skip(),
                         gr.update(value=None, visible=False),
                         completion_message,
                         '',
@@ -3190,7 +3190,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     # 次のバッチに進むメッセージを表示
                     next_batch_message = translate("バッチ処理: {0}/{1} 完了、次のバッチに進みます...").format(batch_index + 1, batch_count)
                     yield (
-                        batch_output_filename if batch_output_filename is not None else gr.update(),
+                        batch_output_filename if batch_output_filename is not None else gr.skip(),
                         gr.update(value=None, visible=False),
                         next_batch_message,
                         '',
@@ -5594,6 +5594,7 @@ with block:
         with gr.Column():
             result_video = gr.Video(
                 label=translate("Finished Frames"),
+                key="result_video",
                 autoplay=True,
                 show_share_button=False,
                 height=512,

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -1935,12 +1935,12 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         # ユーザーにわかりやすいメッセージを表示
         print(translate("\n[INFO] ランダムシード機能が有効なため、指定されたSEED値 {0} の代わりに新しいSEED値 {1} を使用します。").format(previous_seed, seed))
         # UIのseed欄もランダム値で更新
-        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
+        yield gr.skip(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(value=seed)
         # ランダムシードの場合は最初の値を更新
         original_seed = seed
     else:
         print(translate("[INFO] 指定されたSEED値 {0} を使用します。").format(seed))
-        yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
+        yield gr.skip(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
     stream = AsyncStream()
 
@@ -1948,7 +1948,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
     if batch_stopped:
         print(translate("\nバッチ処理が中断されました（バッチ開始前）"))
         yield (
-            gr.update(),
+            gr.skip(),
             gr.update(visible=False),
             translate("バッチ処理が中断されました"),
             '',
@@ -1998,7 +1998,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("\nバッチ処理がユーザーによって中止されました"))
             yield (
-                gr.update(),
+                gr.skip(),
                 gr.update(visible=False),
                 translate("バッチ処理が中止されました。"),
                 '',
@@ -2013,7 +2013,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
             batch_info = translate("バッチ処理: {0}/{1}").format(batch_index + 1, batch_count)
             print(f"\n{batch_info}")
             # UIにもバッチ情報を表示
-            yield gr.update(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
+            yield gr.skip(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
         # 今回処理用のプロンプトとイメージを取得（キュー機能対応）
         current_prompt = prompt
@@ -2093,7 +2093,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         if batch_stopped:
             print(translate("バッチ処理が中断されました。worker関数の実行をキャンセルします。"))
             # 中断メッセージをUIに表示
-            yield (gr.update(),
+            yield (gr.skip(),
                    gr.update(visible=False),
                    translate("バッチ処理が中断されました（{0}/{1}）").format(batch_index, batch_count),
                    '',
@@ -2193,7 +2193,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                 batch_output_filename = data
                 # より明確な更新方法を使用し、preview_imageを明示的にクリア
                 yield (
-                    batch_output_filename if batch_output_filename is not None else gr.update(), 
+                    batch_output_filename if batch_output_filename is not None else gr.skip(), 
                     gr.update(value=None, visible=False), 
                     gr.update(), 
                     gr.update(), 
@@ -2209,7 +2209,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     batch_info = translate("バッチ処理: {0}/{1} - ").format(batch_index + 1, batch_count)
                     desc = batch_info + desc
                 # preview_imageを明示的に設定
-                yield gr.update(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True), gr.update()
+                yield gr.skip(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True), gr.update()
 
             if flag == 'end':
                 # このバッチの処理が終了
@@ -2221,7 +2221,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     else:
                         completion_message = translate("バッチ処理が完了しました（{0}/{1}）").format(batch_count, batch_count)
                     yield (
-                        batch_output_filename if batch_output_filename is not None else gr.update(),
+                        batch_output_filename if batch_output_filename is not None else gr.skip(),
                         gr.update(value=None, visible=False),
                         completion_message,
                         '',
@@ -2236,7 +2236,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     next_batch_message = translate("バッチ処理: {0}/{1} 完了、次のバッチに進みます...").format(batch_index + 1, batch_count)
                     print(translate("\n◆ バッチ {0}/{1} 完了 - 次のバッチに進みます").format(batch_index + 1, batch_count))
                     yield (
-                        batch_output_filename if batch_output_filename is not None else gr.update(),
+                        batch_output_filename if batch_output_filename is not None else gr.skip(),
                         gr.update(value=None, visible=False),
                         next_batch_message,
                         '',
@@ -3358,6 +3358,7 @@ with block:
         with gr.Column():
             result_video = gr.Video(
                 label=translate("Finished Frames"),
+                key="result_video",
                 autoplay=True,
                 show_share_button=False,
                 height=512,

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2220,7 +2220,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
             print(translate("[INFO] lora_dropdown3 = {0}").format(lora_dropdown3))
         print(translate("[INFO] lora_scales_text = {0}").format(lora_scales_text))
     
-    yield gr.update(), None, '', '', gr.update(interactive=False), gr.update(interactive=True)
+    yield gr.skip(), None, '', '', gr.update(interactive=False), gr.update(interactive=True)
     
     # バッチ処理用の変数 - 各フラグをリセット
     batch_stopped = False
@@ -2267,7 +2267,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
         if batch_stopped:
             print(translate("\nバッチ処理がユーザーによって中止されました"))
             yield (
-                gr.update(),
+                gr.skip(),
                 gr.update(visible=False),
                 translate("バッチ処理が中止されました。"),
                 '',
@@ -2281,7 +2281,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
             batch_info = translate("バッチ処理: {0}/{1}").format(batch_index + 1, batch_count)
             print(f"\n{batch_info}")
             # UIにもバッチ情報を表示
-            yield gr.update(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True)
+            yield gr.skip(), gr.update(visible=False), batch_info, "", gr.update(interactive=False), gr.update(interactive=True)
 
         # 今回処理用のプロンプトとイメージを取得（キュー機能対応）
         current_prompt = prompt
@@ -2402,7 +2402,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                     if flag == 'file':
                         output_filename = data
                         yield (
-                            output_filename if output_filename is not None else gr.update(),
+                            output_filename if output_filename is not None else gr.skip(),
                             gr.update(),
                             gr.update(),
                             gr.update(),
@@ -2412,7 +2412,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                     
                     if flag == 'progress':
                         preview, desc, html = data
-                        yield gr.update(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True)
+                        yield gr.skip(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True)
                     
                     if flag == 'end':
                         # endフラグを受信（デバッグログ削除）
@@ -2426,7 +2426,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                             
                             # 完了メッセージでUIを更新
                             yield (
-                                output_filename if output_filename is not None else gr.update(),
+                                output_filename if output_filename is not None else gr.skip(),
                                 gr.update(visible=False),
                                 completion_message,
                                 '',
@@ -2442,7 +2442,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                         print(translate("バッチ処理が中断されました（{0}/{1}）").format(batch_index + 1, batch_count))
                         # endframe_ichiと同様のシンプルな実装に戻す
                         yield (
-                            output_filename if output_filename is not None else gr.update(),
+                            output_filename if output_filename is not None else gr.skip(),
                             gr.update(visible=False),
                             translate("バッチ処理が中断されました"),
                             '',


### PR DESCRIPTION
… event propagations

ブラウザの裏で回していたりするとVideoが度々見えなくなる現象があるのですが、どうやらhtml5のvideo再生の仕組みと、ブラウザのリソース配分の関係で、確実な再現が難しい問題なようです。
リソースを無駄に消費しないようにするのがコツらしいですが、このパッチを当てても、頻度は減少こそすれ、やはり問題が発生するときはあります。難しいですね。


Gradio 公式的にも `gr.skip()` を推奨するようです。
https://www.gradio.app/guides/blocks-and-event-listeners#not-changing-a-components-value

また、videoのおまじないとして、keyも設定しています。
keyを指定するとブラウザ都合でのUI再レンダリングの際、outputとして受け取ったvalueが保存され、VideoがUI上で消失する現象を防げる、かもしれません。
https://www.gradio.app/docs/gradio/video#param-video-key

よろしくお願いいたします。
